### PR TITLE
[Cosmos] Check for process before accessing process.env (Azure#30914)

### DIFF
--- a/sdk/cosmosdb/cosmos/src/utils/supportedQueryFeaturesBuilder.ts
+++ b/sdk/cosmosdb/cosmos/src/utils/supportedQueryFeaturesBuilder.ts
@@ -3,7 +3,7 @@
 import { QueryFeature } from "../common";
 
 export function supportedQueryFeaturesBuilder(disableNonStreamingOrderByQuery?: boolean): string {
-  const disableListAndSetAggregate = process.env.DISABLE_LIST_AND_SET_AGGREGATE === "true";
+  const disableListAndSetAggregate = typeof process !== "undefined" && process.env && process.env.DISABLE_LIST_AND_SET_AGGREGATE === "true";
   if (disableNonStreamingOrderByQuery && disableListAndSetAggregate) {
     return Object.keys(QueryFeature)
       .filter(


### PR DESCRIPTION
### Packages impacted by this PR
@azure/cosmos

### Issues associated with this PR
#30914

### Describe the problem that is addressed by this PR
`process.env` is not defined in non-NodeJS environments and thus makes the function crash


### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
I chose the same style as in [this](https://github.com/Azure/azure-sdk-for-js/blob/1b93964c50923687e47f0b7054c8bba15d2f9694/sdk/cosmosdb/cosmos/src/diagnostics/index.ts#L14) function which performs the same check


### Are there test cases added in this PR? _(If not, why?)_
No, afaik tests are only run in NodeJS

### Provide a list of related PRs _(if any)_
N/A

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_
N/A

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
